### PR TITLE
Fix iter bug when the first child node is despawned before

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -204,10 +204,12 @@ impl<'a, F: Fn(&W, Entity) -> bool + Component, W: GenericWorld, T: Component> I
 
                 // If current is a parent, push a new stack frame with the first child
                 if let Some(parent) = self.parents.view().get(current) {
-                    self.stack.push(StackFrame {
-                        current: parent.view_first_child(&children).unwrap(),
-                        remaining: parent.num_children,
-                    })
+                    if parent.num_children > 0 {
+                        self.stack.push(StackFrame {
+                            current: parent.view_first_child(&children).unwrap(),
+                            remaining: parent.num_children,
+                        })
+                    }
                 }
 
                 return Some(current);
@@ -239,10 +241,12 @@ impl<'a, T: Component> Iterator for DepthFirstIterator<'a, T> {
 
             // If current is a parent, push a new stack frame with the first child
             if let Some(parent) = self.parents.view().get(current) {
-                self.stack.push(StackFrame {
-                    current: parent.view_first_child(&children).unwrap(),
-                    remaining: parent.num_children,
-                })
+                if parent.num_children > 0 {
+                    self.stack.push(StackFrame {
+                        current: parent.view_first_child(&children).unwrap(),
+                        remaining: parent.num_children,
+                    })
+                }
             }
 
             Some(current)


### PR DESCRIPTION
I can reproduce the issue by this test:

```rust
#[test]
fn despawn() {
    let mut world = World::default();
    let root = world.spawn(("Root",));
    let child1 = world.attach_new::<Tree, _>(root, ("Child1",)).unwrap();
    let child2 = world.attach_new::<Tree, _>(root, ("Child2",)).unwrap();
    let child3 = world.attach_new::<Tree, _>(child2, ("Child3",)).unwrap();
    let child4 = world.attach_new::<Tree, _>(root, ("Child4",)).unwrap();
    let child5 = world.attach_new::<Tree, _>(root, ("Child5",)).unwrap();

    world.despawn_all::<Tree>(child3);

    for e in world.descendants_depth_first::<Tree>(root) {  // panic here
        println!("{:?}", *world.get::<&&str>(e).unwrap());
    }
}
``` 

To fix the issue, a conditional check is added to prevent panic in case `first_child` of a parent node is removed.