### PR TITLE
Fix despawning tree leaf

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -138,7 +138,7 @@ impl HierarchyMut for World {
             Ok(())
         })?;
 
-        self.remove_one::<Parent<T>>(parent).unwrap();
+        self.try_remove_one::<Parent<T>>(parent)?;
 
         Ok(children)
     }
@@ -151,7 +151,7 @@ impl HierarchyMut for World {
             .iter()
             .for_each(|child| self.despawn_all::<Child<T>>(*child));
 
-        self.remove_one::<Parent<T>>(parent).unwrap();
+        self.try_remove_one::<Parent<T>>(parent)?;
 
         Ok(())
     }
@@ -167,10 +167,16 @@ impl HierarchyMut for World {
         self.try_get_mut::<Child<T>>(prev)?.next = next;
         self.try_get_mut::<Child<T>>(next)?.prev = prev;
 
-        let mut parent = self.try_get_mut::<Parent<T>>(parent)?;
-        parent.num_children -= 1;
-        if parent.last_child == child {
-            parent.last_child = prev;
+        let mut remove_parent = false;
+        {
+            let mut parent_comp = self.try_get_mut::<Parent<T>>(parent)?;
+            parent_comp.num_children -= 1;
+            if parent_comp.num_children == 0 {
+                remove_parent = true;
+            }
+        }
+        if remove_parent {
+            self.try_remove_one::<Parent<T>>(parent)?;
         }
 
         Ok(())

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -171,6 +171,27 @@ fn despawn() {
 }
 
 #[test]
+fn despawn_last_child() {
+    let mut world = World::default();
+    let root = world.spawn(("Root",));
+
+    let child1 = world.attach_new::<Tree, _>(root, ("Child1",)).unwrap();
+
+    world.despawn_all::<Tree>(child1);
+
+    let child2 = world.attach_new::<Tree, _>(root, ("Child2",)).unwrap();
+
+    assert_eq!(world.children::<Tree>(root).count(), 1);
+
+    assert_eq!(
+        world
+            .descendants_depth_first::<Tree>(root)
+            .collect::<Vec<_>>(),
+        vec![child2]
+    );
+}
+
+#[test]
 fn dfs() {
     // Root ---- Child 1
     //      ---- Child 2


### PR DESCRIPTION
Currently, this test fails:
```rust
#[test]
fn despawn_last_child() {
    let mut world = World::default();
    let root = world.spawn(("Root",));

    let child1 = world.attach_new::<Tree, _>(root, ("Child1",)).unwrap();

    world.despawn_all::<Tree>(child1);

    // Crash here since `Parent<Tree>` component of root is looking for child1
    let child2 = world.attach_new::<Tree, _>(root, ("Child2",)).unwrap();
}
```

This is because `HierarchyMut::detach` does not detach the `Parent<T>` component of the parent entity if the entity we removed was its only child. Instead it sets `parent.last_child = prev` which doesn't do anything since `last_child` is already `prev` and the entity we're removing.

This PR fixes this by removing the `Parent<T>` and adds a test against it.